### PR TITLE
[0.1] Add support for documentation versioning

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - release-0.1
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
+      - run: pip install mike
       - run: pip install mkdocs-material
       - run: pip install mkdocs-render-swagger-plugin
-      - run: mkdocs gh-deploy --force
+      - run: mike deploy --push --rebase --update-aliases v0.1 latest
+      - run: mike set-default --push --rebase latest

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -9,11 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
       - run: pip install mike
       - run: pip install mkdocs-material
       - run: pip install mkdocs-render-swagger-plugin
+      - name: setup doc deploy
+        run: |
+          git config --global user.name FuseML
+          git config --global user.email docs@fuseml
       - run: mike deploy --push --rebase --update-aliases v0.1 latest
       - run: mike set-default --push --rebase latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
+      - run: pip install mike
       - run: pip install mkdocs-material
       - run: pip install mkdocs-render-swagger-plugin
       - run: mkdocs build --strict

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,3 +21,7 @@ plugins:
 
 # TODO: Validate with our legal team.
 copyright: "Copyright &copy; 2021 FuseML Author(s)"
+
+extra:
+  version:
+    provider: mike


### PR DESCRIPTION
This commit introduces [mike] (https://github.com/jimporter/mike) as a documentation versioning plugin.

The documentation in the release-0.1 branch will appear under a `v0.1`
version. This version will also be the latest and default documentation
version until FuseML 0.2 is released.