### PR TITLE
[0.1] Stop using latest for 0.1 docs

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -21,5 +21,4 @@ jobs:
         run: |
           git config --global user.name FuseML
           git config --global user.email docs@fuseml
-      - run: mike deploy --push --rebase --update-aliases v0.1 latest
-      - run: mike set-default --push --rebase latest
+      - run: mike deploy --push --rebase --update-aliases v0.1


### PR DESCRIPTION
Stop publishing the docs from the 0.1 release as default/latest in
preparation of the 0.2 release.