### PR TITLE
[0.3] Document workflows and extensions

### DIFF
--- a/docs/extensions/extension-registry.md
+++ b/docs/extensions/extension-registry.md
@@ -14,7 +14,7 @@ To explore more on the use-cases for which the Extension Registry was intended, 
 
 ## Extension Records
 
-The structure of the information captured in the Extension Registry (i.e. the Extension Records) is based on common architectural and deployment patterns and abstractions exhibited by and extracted from a wide range of AI/ML tools and services, but is particularly suitable to describe cloud-native applications and services. The Extension Record is represented by a hierarchy of elements (services, endpoints, credentials and configuration) that can be used to model any 3rd party service in a form that can be easily referenced and consumed by FuseML and automated workflows.
+The structure of the information captured in the Extension Registry (i.e. the Extension Records) is based on common architectural and deployment patterns and abstractions exhibited by and extracted from a wide range of AI/ML tools and services, but is particularly suited to describe cloud-native applications and services. The Extension Record is represented by a hierarchy of elements (services, endpoints, credentials and configuration) that can be used to model any 3rd party service in a form that can be easily referenced and consumed by FuseML and automated workflows.
 
 Below is an example of an Extension Record describing an MLFlow server instance deployed in a Kubernetes cluster. In fact, it is the exact Extension Record that is automatically registered when MLFlow is installed using the FuseML installer.
 

--- a/docs/extensions/extension-registry.md
+++ b/docs/extensions/extension-registry.md
@@ -1,0 +1,580 @@
+# FuseML Extension Registry
+
+## Overview
+
+FuseML maintains a central registry where it keeps information about the available extensions and 3rd party tools that it integrates with. This information can be interactively consumed by users, but more importantly, is available as input for workflows and for other control plane features that we plan to add to FuseML in the future, such as multi-cluster AI/ML resource and service management.
+
+The immediate application of an extension registry is to provide a place where endpoints, URLs, credentials and other data required to access 3rd party AI/ML tools like data stores, artifact stores, hyperparameter tuning and distributed training tools and prediction service platforms can be stored and accessed by the container images implementing workflow steps.
+
+The information in the Extension Registry can be populated by end users [through the CLI](../cli.md#extensions) or [through the REST API](../api.md). In addition to explicit registration, the FuseML installer automatically handles all registration and de-registration matters for the 3rd party tools and services that are installed through it.
+
+To understand what information is needed to _model and register your own instance of AI/ML tool or service as a FuseML extension_ and then _reference it and access it from FuseML workflows_, please proceed to the next sections describing the [Extension Record format](#extension-records) and the [workflow extension references](#referencing-extensions-in-workflows).
+
+To explore more on the use-cases for which the Extension Registry was intended, please refer to the [Extension Registry Use Cases section](#extension-registry-use-cases).
+
+## Extension Records
+
+The structure of the information captured in the Extension Registry (i.e. the Extension Records) is based on common architectural and deployment patterns and abstractions exhibited by and extracted from a wide range of AI/ML tools and services, but is particularly suitable to describe cloud-native applications and services. The Extension Record is represented by a hierarchy of elements (services, endpoints, credentials and configuration) that can be used to model any 3rd party service in a form that can be easily referenced and consumed by FuseML and automated workflows.
+
+Below is an example of an Extension Record describing an MLFlow server instance deployed in a Kubernetes cluster. In fact, it is the exact Extension Record that is automatically registered when MLFlow is installed using the FuseML installer.
+
+```yaml
+id: mlflow
+product: mlflow
+version: 1.20.2
+description: |
+  MLFlow is an open source platform specialized in tracking ML experiments, and packaging and deploying ML models.
+services:
+- id: mlflow-tracking
+  resource: mlflow-tracking
+  category: experiment-tracking
+  authrequired: false
+  description: MLFlow experiment tracking service API and UI
+  endpoints:
+  - url: http://mlflow.mlflow
+    type: internal
+    configuration:
+      MLFLOW_TRACKING_URI: http://mlflow.mlflow
+- id: mlflow-store
+  resource: s3
+  category: model-store
+  authrequired: true
+  description: MLFlow minio S3 storage back-end
+  endpoints:
+  - url: http://mlflow-minio.mlflow:9000
+    type: internal
+    configuration:
+      MLFLOW_S3_ENDPOINT_URL: http://mlflow-minio.mlflow:9000
+  credentials:
+  - id: default-s3-account
+    default: false
+    scope: global
+    projects: []
+    users: []
+    configuration:
+      AWS_ACCESS_KEY_ID: <hidden>
+      AWS_SECRET_ACCESS_KEY: <hidden>
+```
+
+As can be seen from the descriptor, an MLFlow server consists of two services: the experiment tracking service and the artifact store. The experiment tracking service is responsible for tracking and visualizing ML experiments. The artifact store (in our case backed by [minio - an S3 object store](https://min.io/)) is the service responsible for storing ML artifacts, such as ML models, datasets and logs. Services have individual endpoints through which they can be accessed. The artifact store in particular requires authentication, which is why credentials are also provided.
+
+!!! note
+
+    In different circumstances, we wouldn't need to include the artifact store back-end as a separate service in the extension descriptor, for example if the MLflow tracking server API would act as a central proxy intermediating uploading and downloading of artifacts. However, in this case, the external clients need to interact directly with the MLflow artifact store back-end to upload/download artifacts, which is why we need to cover it as a standalone service under the same extension.
+
+Next, let's take a closer look at the different sections (elements) that make up an Extension Record and explore their utility:
+
+```yaml
+id: mlflow
+product: mlflow
+version: 1.20.2
+description: |
+  MLFlow is an open source platform specialized in tracking ML experiments, and packaging and deploying ML models.
+```
+
+An Extension Record is identified by its `id` and represents a single instance or installation of a framework/platform/service/product developed and released or hosted under a unique name and operated as a single cohesive unit. Different installations of the same product can be grouped together based on the `product` and `version` they were installed from. They can also be grouped together based on the the infrastructure domain (i.e. location, region, zone, area or kubernetes cluster) where the extension is running, based on a `zone` identifier (not depicted here).
+
+```yaml
+[...]
+services:
+- id: mlflow-tracking
+  resource: mlflow-tracking
+  category: experiment-tracking
+  authrequired: false
+  description: MLFlow experiment tracking service API and UI
+  [...]
+- id: mlflow-store
+  resource: s3
+  category: model-store
+  authrequired: true
+  description: MLFlow minio S3 storage back-end
+  [...]
+```
+
+Several individual `services`, that can be consumed separately, can be provided by the same extension. In our example, an MLFlow instance is composed of an experiment tracking service API/UI and an artifact store service. A `service` is represented by a single exposed API or UI. For extensions implemented as cloud-native applications, a `service` is the equivalent of a Kubernetes service that is used to expose a public API or UI. `Services` are also classified into known resource types (e.g. s3, git, ui) and service categories (e.g. model store, feature store, prediction platform), to make it easier to create _portable workflows_: where a workflow step lists a service type and/or a category as a requirement, and FuseML automatically resolves that to whatever particular service instance is available at runtime. Together with the extension `product` and `version`, the resource type and service category can be used to uniquely identify a service or group of services independently of how and where they are deployed.
+
+```yaml
+services:
+- id: mlflow-tracking
+  [...]
+  endpoints:
+  - url: http://mlflow.mlflow
+    type: internal
+- id: mlflow-store
+  [...]
+  endpoints:
+  - url: http://mlflow-minio.mlflow:9000
+    type: internal
+```
+
+A `service` is exposed through several individual `endpoints`. Having a list of `endpoints` associated with a single `service` is particularly important for representing Kubernetes services, which can be exposed both internally (cluster IP) and externally (e.g. ingress or load balancer IP). Depending on the consumer location, FuseML can choose the endpoint that is accessible to and closer to the consumer. All `endpoints` grouped under the same `service` must be equivalent in the sense that they are backed by the same API and/or protocol. Our example only features internal endpoints; this implies that the APIs can only be consumed by automated FuseML workflows that are running in the same Kubernetes cluster as the MLflow server instance.
+
+```yaml
+services:
+[...]
+- id: mlflow-store
+  [...]
+  credentials:
+  - id: default-s3-account
+    default: false
+    scope: global
+    projects: []
+    users: []
+    configuration:
+      AWS_ACCESS_KEY_ID: <hidden>
+      AWS_SECRET_ACCESS_KEY: <hidden>
+```
+
+A `service` can be accessed using one of several sets of `credentials`. A set of `credentials` can be generally used to embed information pertaining to the authentication and authorization features supported by a service. This element allows administrators and operators of 3rd party tools integrated with FuseML to configure different accounts and credentials (tokens, certificates, passwords) to be associated with different FuseML organization entities (users, projects, groups etc.). In our MLflow case, all clients, FuseML workflows included, need S3 credentials to be able to upload/download artifacts from the S3 artifact store.
+
+```yaml
+[...]
+services:
+- id: mlflow-tracking
+  [...]
+  endpoints:
+  - url: http://mlflow.mlflow
+    type: internal
+    configuration:
+      MLFLOW_TRACKING_URI: http://mlflow.mlflow
+- id: mlflow-store
+  [...]
+  endpoints:
+  - url: http://mlflow-minio.mlflow:9000
+    type: internal
+    configuration:
+      MLFLOW_S3_ENDPOINT_URL: http://mlflow-minio.mlflow:9000
+  credentials:
+  - id: default-s3-account
+    [...]
+    configuration:
+      AWS_ACCESS_KEY_ID: <hidden>
+      AWS_SECRET_ACCESS_KEY: <hidden>
+```
+
+`Configuration` elements can be present under the top level as well as the `services`, `endpoints` and `credentials` elements and represent opaque, service specific configuration data that the consumers need in order to access a service interface. `Configuration` elements can be used to encode any information relevant for service clients: accounts and credentials, information describing the service or particular configuration parameters that describe how the service should be used. For example, if endpoints are SSL secured, custom certificates (e.g. self-signed CA certificates or client certificates) might be needed to access them and this should be included in the endpoint configuration. The information encoded in a `configuration` element is treated as sensitive information (stored securely and not exposed through the API) when present under `credentials`. These are the equivalent of Kubernetes configmaps (or secrets, when under `credentials`).
+
+### Extension Examples
+
+This section contains more Extension Record examples, featuring some common configurations and scenarios.
+
+1. an MLFlow instance deployed locally alongside FuseML and globally accessible. This is similar to the example analyzed in the previous section, but also includes external endpoints:
+
+    ```yaml
+    id: mlflow-0001
+    product: mlflow
+    version: "1.19.0"
+    description: MLFlow experiment tracking and artifact store
+    zone: cluster-alpha
+    services:
+      - id: mlflow-tracking
+        resource: mlflow-tracking
+        category: experiment-tracking
+        description: MLFlow experiment tracking service API and UI
+        endpoints:
+          - url: http://mlflow.mlflow
+            type: internal
+            configuration:
+              MLFLOW_TRACKING_URI: http://mlflow.mlflow
+          - url: http://mlflow.10.110.120.130.nip.io
+            type: external
+            configuration:
+              MLFLOW_TRACKING_URI: http://mlflow.10.110.120.130.nip.io
+      - id: mlflow-store
+        resource: s3
+        category: model-store
+        description: MLFlow minio S3 storage back-end
+        credentials:
+          - id: default-s3-account
+            scope: global
+            configuration:
+              AWS_ACCESS_KEY_ID: 24oT0SfbJPEu6kUbUKsH
+              AWS_SECRET_ACCESS_KEY: cMGiZff8KqS5xWQ4eagRujh1tDcbQyRP0bEJSBOf
+        endpoints:
+          - url: http://mlflow-minio.mlflow:9000
+            type: internal
+            configuration:
+              MLFLOW_S3_ENDPOINT_URL: http://mlflow-minio.mlflow:9000
+          - url: http://minio.10.110.120.130.nip.io
+            type: external
+            configuration:
+              MLFLOW_S3_ENDPOINT_URL: http://minio.10.110.120.130.nip.io
+    ```
+
+2. example showing that the minio service deployed as a sub-component of the previous MLFlow instance can also be registered as a generic minio/S3 service, although this is not recommended, because even though the S3 service can be accessed and used independently of the parent MLflow tracking server, the way that artifact store data is organized and stored in the S3 back-end is specific to MLFlow and should be discoverable as such:
+
+    ```yaml
+    id: mlflow-model-store-0001
+    product: minio
+    version: "4.1.3"
+    description: Minio S3 storage service
+    zone: cluster-alpha
+    services:
+      - id: s3
+        resource: s3
+        category: object-storage
+        description: MLFlow minio S3 storage back-end
+        credentials:
+          - id: default
+            scope: global
+            configuration:
+              AWS_ACCESS_KEY_ID: 24oT0SfbJPEu6kUbUKsH
+              AWS_SECRET_ACCESS_KEY: cMGiZff8KqS5xWQ4eagRujh1tDcbQyRP0bEJSBOf
+        endpoints:
+          - url: http://mlflow-minio.mlflow:9000
+            type: internal
+          - url: http://mlflow.10.110.120.130.nip.io
+            type: external
+    ```
+
+3. example of an extension record for a 3rd party Gitea instance running in a zone other than FuseML. A dedicated `fuseml-admin` Gitea user was configured explicitly for FuseML and the credentials are provided in the extension record: 
+
+    ```yaml
+    id: gitea-devel-rd
+    product: gitea
+    version: "1.14.3"
+    description: Gitea version control server running in the R&D cloud
+    zone: rd-cloud
+    services:
+      - id: git_https
+        resource: git+https
+        category: VCS
+        description: Gitea git/http API
+        endpoints:
+          - url: https://gitea.rd-cloud.mydomain.org
+            type: external
+        credentials:
+          - id: admin
+            scope: global
+            configuration:
+              username: fuseml-admin
+              password: 8KqS5xWQ4eagRu
+    ```
+
+4. example showing two different extension records, instances of different products, that provide the same type of resource/API. FuseML reusable workflows can reference any of these extension instances with a `resource: s3` selector and FuseML will connect them at runtime to the one that is available in the zone where they're running:
+
+    ```yaml
+    id: minio-s3-storage
+    product: minio
+    version: "4.1.3"
+    description: Minio S3 storage services
+    zone: development-cluster
+    services:
+      - id: s3
+        resource: s3
+        category: object-storage
+        description: Minio S3 storage deployed in the development cluster
+        credentials:
+          - id: local-minio
+            scope: global
+            configuration:
+              AWS_ACCESS_KEY_ID: 24oT0SfbJPEu6kUbUKsH
+              AWS_SECRET_ACCESS_KEY: cMGiZff8KqS5xWQ4eagRujh1tDcbQyRP0bEJSBOf
+        endpoints:
+          - url: http://minio.minio:9000
+            type: internal
+          - url: http://minio.10.110.120.130.nip.io
+            type: external
+    ```
+
+    ```yaml
+    id: aws-object-storage
+    product: aws-s3
+    description: AWS cloud object storage
+    zone: eu-central-1
+    services:
+      - id: aws
+        resource: s3
+        category: object-storage
+        description: AWS S3 object storage
+        credentials:
+          - id: aws
+            scope: global
+            configuration:
+              AWS_ACCESS_KEY_ID: sWRS24oT0SfbJPEu6kU3EWf
+              AWS_SECRET_ACCESS_KEY: abl4SDcMGiZff8KqS5xWQ4eagRujh1tDcbQyRP0s
+        endpoints:
+          - url: https://s3.eu-central-1.amazonaws.com
+            type: external
+    ```
+
+5. this next extension record shows KServe as an example of a Kubernetes controller running in the same cluster as FuseML. No credentials need to be configured, since the FuseML workflows are running in the same cluster and will be able to access the KServe API through the special Kubernetes service account configured by FuseML and in the context of which all workflow containers are running. The extension record also shows how the KServe UI is exposed as a second external service.
+
+    !!! note
+
+        The FuseML installer takes care of setting up the proper roles and permissions for the Kubernetes service account to access the KServe API, only if KServe is installed through the FuseML installer. Otherwise, the FuseML admin needs to explicitly configure additional roles and permissions for the `fuseml-workloads/fuseml-workloads` Kubernetes service account to allow the workflow containers to access the KServe API. 
+
+    ```yaml
+    id: kserve-local
+    product: kserve
+    version: "0.7.0"
+    description: KServe prediction service platform running in the local cluster
+    zone: cluster.local
+    services:
+      - id: API
+        resource: kfserve-api
+        category: prediction-serving
+        description: KServe prediction service API
+        endpoints:
+          - url: https://kubernetes.default.svc
+            type: internal
+      - id: UI
+        resource: kserve-ui
+        category: UI
+        description: KServe prediction platform UI
+        endpoints:
+          - url: https://kserve.10.120.130.140.nip.io/
+            type: external
+    ```
+
+6. this extension record shows Seldon Core as an example of a Kubernetes service running in a cluster different than the one where FuseML is located and where workflows are executed. In this case, Kubernetes credentials need to be explicitly provided with the extension record to give the workflows access to the cluster API. The admin also decided to be more restrictive about how this remote cluster is used by FuseML and to configure explicit project-scope and user-scope credentials that only allow workflows running in the context of the FuseML projects `alpha` and `beta` to access it.
+
+    ```yaml
+    id: seldon-core-production
+    product: seldon
+    version: "1.11.0"
+    zone: production-cluster-001
+    description: Seldon Core inference serving platform running in production cluster
+    services:
+      - id: API
+        resource: seldon-core-api
+        category: prediction-serving
+        description: Seldon Core prediction serving platform API
+        credentials:
+          - id: project-alpha
+            scope: project
+            projects:
+              - alpha
+            configuration:
+              CLIENT_CERT: LS0tLS1CRUdJTiBDRVJUSUZJQ0FU[...]RS0tLS0tCk1JSUM4akNDQNBVEUtLS0tLQo=
+              CLIENT_KEY: cMGiZff8KqS5xW[...]Q4eagRujh1tDcbQyRP0bEJSBOf
+              CLUSTER_CERT_AUTH: VsSCsdfLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0[...]tLS0tCk1anF1TT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+          - id: user-alainturing
+            scope: user
+            projects:
+              - alpha
+              - beta
+            users:
+              - alainturing
+            configuration:
+              CLIENT_CERT: GHLS0t1CRUdJTiBDRVJUSUZJQ0F[...]URS0tLS0tCk1JSUM4akNDQWRxZ0F3BVEUtLS0tLQo=
+              CLIENT_KEY: TyGiZff8KqS5xWQ4eag[...]Rujh1tDcbQyRP0bEJSBOf
+              CLUSTER_CERT_AUTH: VsSCsdfLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0[...]tLS0tCk1anF1TT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+        endpoints:
+          - url: https://production-cluster-xasf.example.com:6443
+            type: external
+        configuration:
+          INSECURE: False
+          namespace: prj_hys568
+    ```
+
+## Referencing Extensions in Workflows
+
+FuseML workflows can reference extensions in the same way as other resources. An extension selector can be included in the definition of a workflow step to indicate the type and/or capabilities of one or more external services that the workflow step needs to interact with, such as a data store, an experiment tracking tool, an artifact store, or any other type of machine learning service that implements a function in the MLOps lifecycle. FuseML automatically connects the workflow steps to their required external services based on the information it finds in the extension selectors and the extension records that are available in the Extension Registry. 
+
+The extension selector that can be specified for a workflow step has the following syntax:
+
+```yaml
+[...]
+  steps:
+  [...]
+    - name: <step-name>
+      [...]
+      extensions:
+        - name: <extension-selector-name>
+          extension_id: <extension-id>
+          service_id: <service-id>
+          zone: <extension-zone>
+          product: <extension-product>
+          version: <extension-version-or-semantic-version-constraint>
+          service_category: <service-category>
+          service_resource: <service-resource>
+```
+
+FuseML users have a wide range of possibilities when it comes to referencing extensions in their workflows. A workflow step can be configured to request a particular service instance by defining a very strict extension selector, one that identifies the service instance explicitly by including its `extension_id` and `service_id`. This is the most restrictive way to reference an extension in a workflow and results in the least flexibility.
+
+For more flexible and portable workflows, it is recommended to identify extensions and services by their product or the category of service and/or resource that they provide. This can be done by setting one or more of the fields `product`, `version`, `service_category` and `service_resource` in the extension selector. This approach creates workflows that are reusable and portable across different deployments, infrastructure zones and even products.
+
+When a workflow is executed, FuseML maps all the `configuration` values gathered from the extension records that match the configured selectors and converts them into environment variables that are injected into the containers corresponding to each step. It is up the implementation of individual workflow steps to interpret the values of these environment variables and to use them to access the external services that they need to interact with. Furthermore, when the environment variables extracted from extension records don't map to what is expected by a workflow step container, the workflow can be configured to explicitly map these values to something else, as depicted in one of the examples in the next section.
+
+### Extension Selector Examples
+
+This section contains examples of extension selectors that can be used in workflows, featuring some common configurations and scenarios.
+
+1. explicitly referencing a particular service instance by its `extension_id` and `service_id` in a workflow step:
+
+    ```yaml
+    [...]
+    steps:
+      [...]
+      - name: trainer
+        [...]
+        extensions:
+          - name: experiment-tracking
+            extension_id: mlflow-0001
+            service_id: mlflow-tracking
+          - name: artifact-store
+            extension_id: mlflow-0001
+            service_id: mlflow-store
+    ```
+
+    Provided that the Extension Registry contains the MLflow extension record featured in the one of the extension records example:
+
+    ```yaml
+    id: mlflow-0001
+    product: mlflow
+    version: "1.19.0"
+    description: MLFlow experiment tracking and artifact store
+    zone: cluster-alpha
+    services:
+      - id: mlflow-tracking
+        resource: mlflow-tracking
+        category: experiment-tracking
+        description: MLFlow experiment tracking service API and UI
+        endpoints:
+          - url: http://mlflow.mlflow
+            type: internal
+            configuration:
+              MLFLOW_TRACKING_URI: http://mlflow.mlflow
+          - url: http://mlflow.10.110.120.130.nip.io
+            type: external
+            configuration:
+              MLFLOW_TRACKING_URI: http://mlflow.10.110.120.130.nip.io
+      - id: mlflow-store
+        resource: s3
+        category: model-store
+        description: MLFlow minio S3 storage back-end
+        credentials:
+          - id: default-s3-account
+            scope: global
+            configuration:
+              AWS_ACCESS_KEY_ID: 24oT0SfbJPEu6kUbUKsH
+              AWS_SECRET_ACCESS_KEY: cMGiZff8KqS5xWQ4eagRujh1tDcbQyRP0bEJSBOf
+        endpoints:
+          - url: http://mlflow-minio.mlflow:9000
+            type: internal
+            configuration:
+              MLFLOW_S3_ENDPOINT_URL: http://mlflow-minio.mlflow:9000
+          - url: http://minio.10.110.120.130.nip.io
+            type: external
+            configuration:
+              MLFLOW_S3_ENDPOINT_URL: http://minio.10.110.120.130.nip.io
+    ```
+
+    , FuseML will resolve the extension selector to this extension record and its internal endpoints. The `configuration` values of the extension record will be mapped to the following implicit environment variables that passed to the container:
+
+    ```yaml
+    MLFLOW_TRACKING_URI: http://mlflow.mlflow
+    MLFLOW_S3_ENDPOINT_URL: http://mlflow-minio.mlflow:9000
+    AWS_ACCESS_KEY_ID: 24oT0SfbJPEu6kUbUKsH
+    AWS_SECRET_ACCESS_KEY: cMGiZff8KqS5xWQ4eagRujh1tDcbQyRP0bEJSBOf
+    ```
+
+2. referencing a service independently of running instance, by using the product and service resource identifiers and including a version specifier to ensure compatibility:
+
+    ```yaml
+    [...]
+    steps:
+      [...]
+      - name: predictor
+        [...]
+        extensions:
+          - name: kserve
+            product: kserve
+            service_resource: kserve-api
+            version: "~1.10.0"
+    ```
+
+3. example of a minimal reference, specifying only the resource type
+
+    ```yaml
+    [...]
+    steps:
+      [...]
+      - name: trainer
+        [...]
+        extensions:
+          - name: experiment-tracking
+            service_resource: mlflow-tracking
+          - name: artifact-store
+            service_resource: s3
+    ```
+
+4. this workflow step explicitly uses FuseML workflow expressions to map new environment variable names to the configuration entries from the extension record instead of relying on the default ones extracted from the extension record. It also accesses other fields in the extension record to perform additional actions:
+
+    ```yaml
+    [...]
+    steps:
+      [...]
+      - name: trainer
+        [...]
+        extensions:
+          - name: experiment-tracking
+            product: mlflow
+            service_resource: mlflow-tracking
+          - name: artifact-store
+            product: mlflow
+            service_resource: s3
+        env:
+          - name: S3_ACCESS_KEY_ID
+            value: '{{ extension.artifact-store.cfg.AWS_ACCESS_KEY_ID }}'
+          - name: S3_SECRET_ACCESS_KEY
+            value: '{{ extension.artifact-store.cfg.AWS_SECRET_ACCESS_KEY }}'
+          - name: MLFLOW_TRACKER_URL
+            value: '{{ extension.experiment-tracking.url }}'
+          - name: MLFLOW_TRACKER_VERSION
+            value: '{{ extension.experiment-tracking.version }}'
+          - name: MLFLOW_TRACKER_ZONE
+            value: '{{ extension.experiment-tracking.zone }}'
+    ```
+
+5. a similar approach is to use the FuseML workflow expressions to expand fields in the extension record and use them as values for workflow step inputs:
+
+    ```yaml
+    [...]
+    steps:
+      [...]
+      - name: trainer
+        [...]
+        inputs:
+          [...]
+          - name: s3_access_key
+            value: '{{ extension.artifact-store.cfg.AWS_ACCESS_KEY_ID }}'
+          - name: s3_secret_access_key
+            value: '{{ extension.artifact-store.cfg.AWS_SECRET_ACCESS_KEY }}'
+          - name: s3_endpoint_url
+            value: '{{ extension.artifact-store.url }}'
+        extensions:
+          - name: artifact-store
+            service_resource: s3
+    ```
+
+## Extension Registry Use Cases
+
+The extension registry targets some of the following use-cases:
+
+1. as an Ops engineer (MLOps/DevOps/ITOps), I need a way to configure my FuseML instance with the parameters required to dynamically integrate with 3rd party AI/ML tools (e.g. URLs, endpoints, credentials, other tool specific configuration attributes). For non-production environments, this requirement can also come from ML Engineers or even Data Scientists that are looking to quickly set up FuseML for experimentation purposes.
+
+    Examples:
+
+    * Data Scientist: I have an MLFlow tracking service already set up by me that I use for my ML experiments and I want to reuse it for FuseML automated workflows. I will configure FuseML with the information it needs to access the MLFlow tracking service (the tracker service URL and the hostname, username and keys for the storage backend). The information is stored in a central registry where FuseML workflows can access it.
+    * Data Scientist: I'm using my Google cloud storage account to store datasets or ML models that I use in my local experiments. I want my FuseML automated workflows to upload/download artifacts using that same storage account, but I don't want to expose my credentials in the workflow definition or in the code I'm pushing to FuseML. I'll store those credentials in the FuseML extension registry and access them from my FuseML workflow steps.
+    * Ops engineer: I have an S3 storage service set up for my organization and I want to use that as a storage backend for FuseML artifacts (e.g. models, datasets).
+    I will manage buckets, accounts and credentials and add them as extension records in the FuseML extension registry. ML engineers and DSs can then write FuseML workflows that have access to the S3 storage service without having to deal with these operational details.
+
+
+2. as a ML engineer or Data Scientist, I need a list of the 3rd party tools that my FuseML instance is integrated with, to help me make decisions about how I implement and run my ML experiments and how I design my FuseML workflows
+
+3. as a ML engineer or Data Scientist, I want to design FuseML workflows consisting of steps that interact with my AI/ML tool stack of choice, independently of how those tools are deployed. This makes my workflows generic and reusable:
+
+    * FuseML workflow definitions don't need to be updated when there are changes in the configuration of the 3rd party tools (e.g. upgrade, migration) or in the way they are integrated with FuseML (e.g. change of accounts, change in access permissions or credentials)
+    * configuring and integrating the tools with FuseML and configuring the FuseML workflows are independent operations and can be done by different roles requiring minimum interaction
+    * a FuseML workflow, once defined, can be executed across multiple FuseML instances and 3rd party tools deployment configurations, as long as the same set of tools are involved
+
+    Examples:
+
+    * Data Scientist: I'm writing a FuseML workflow to automate the end-to-end lifecycle of my ML model. I wrote my ML code using MLFlow during the experimentation phase so I want to also use MLFlow as a tracking service and model store for my workflow. I also want to use Seldon Core as an inference service platform. These tools (MLFlow and Seldon Core) have already been installed by DevOps and set up as entries in the FuseML extension registry. All I need to do is specify in the definition of my FuseML workflows which step requires which extension, and the FuseML orchestrator will automatically make that information available to the container images implementing those steps. This way, I don't need to concern myself with endpoints, accounts or credentials.
+    * Ops engineer: I need to migrate the on-prem S3 storage service used by my organization to a new location. I'm also using this storage service for a range of FuseML service instances in use by various AI/ML teams. All I need to do to re-configure the FuseML services is to update the entries I previously configured in their extension registries to point to the new URL. Future workflow executions will automatically pick-up the new values.
+    * ML engineer: I'm using a staged approach to automating the deployment of my ML model in production. I have a development environment, a staging/testing environment and a production environment. I can write a complex FuseML workflow that I can reuse across these environments with minimal changes. The workflow definition is independent of how the 3rd party tools are deployed and set up for access by FuseML in these environments.
+
+

--- a/docs/extensions/installer-extensions.md
+++ b/docs/extensions/installer-extensions.md
@@ -6,7 +6,7 @@ The FuseML installer can be used for more than installing FuseML itself. It can 
 
 The installer makes a clear distinction between basic mandatory components and extensions for 3rd party tools, but at the same time provides the "all-in-one" experience of installing everything in one shot. Furthermore, the installer is flexible in that it can be extended dynamically to cover more third-party tools and services that are not included in the default tool stack maintained by the FuseML team, by defining new [Installer Extensions](#installer-extensions) and grouping them under a custom [Installer Extension Repository](#installer-extension-repository).
 
-The [default FuseML Installer Extension Repository](https://github.com/fuseml/extensions/tree/main/installer) includes a variety of AI/ML tools that can be installed through the FuseML installer. The repository is maintained by the FuseML team and is updated regularly.
+The [default FuseML Installer Extension Repository](https://github.com/fuseml/extensions/tree/release-0.3/installer) includes a variety of AI/ML tools that can be installed through the FuseML installer. The repository is maintained by the FuseML team and is updated regularly.
 
 ## Installer Extensions
 
@@ -195,7 +195,7 @@ Some third party AI/ML services, like KServe, come in the form of Kubernetes ope
 
     All steps in a FuseML workflow are executed in the `fuseml-workloads` Kubernetes namespace and in the context of the `fuseml-workloads` service account. For 3rd party tools that are not installed using installer extensions, or that do not include `rolerules` in the extension descriptor, the admin must manually add the required permissions to the `fuseml-workloads` service account. FuseML automatically adds the permissions listed in the `rolerules` section to the mentioned service account.
 
-For more examples of extension descriptors and how to build them, take a look at the [Installer Extension Repository maintained by the FuseML team](https://github.com/fuseml/extensions/tree/main/installer)
+For more examples of extension descriptors and how to build them, take a look at the [Installer Extension Repository maintained by the FuseML team](https://github.com/fuseml/extensions/tree/release-0.3/installer)
 
 ## Installer Extension Repository
 
@@ -214,7 +214,7 @@ extensions
     - uninstall.sh
 ```
 
-The FuseML installer defaults to using the [Installer Extension Repository maintained by the FuseML team](https://github.com/fuseml/extensions/tree/main/installer). To point it to a different location, the optional `--extension-repository` command line argument can be used.
+The FuseML installer defaults to using the [Installer Extension Repository maintained by the FuseML team](https://github.com/fuseml/extensions/tree/release-0.3/installer). To point it to a different location, the optional `--extension-repository` command line argument can be used.
 
 
 

--- a/docs/extensions/installer-extensions.md
+++ b/docs/extensions/installer-extensions.md
@@ -1,0 +1,221 @@
+## Installation of 3rd party tools and services with the FuseML installer
+
+## Overview
+
+The FuseML installer can be used for more than installing FuseML itself. It can also be used to manage the installation of third-party tools and services and their subsequent registration in [the FuseML Extension Registry](extension-registry.md), where they can be referenced and accessed from FuseML workflows.
+
+The installer makes a clear distinction between basic mandatory components and extensions for 3rd party tools, but at the same time provides the "all-in-one" experience of installing everything in one shot. Furthermore, the installer is flexible in that it can be extended dynamically to cover more third-party tools and services that are not included in the default tool stack maintained by the FuseML team, by defining new [Installer Extensions](#installer-extensions) and grouping them under a custom [Installer Extension Repository](#installer-extension-repository).
+
+The [default FuseML Installer Extension Repository](https://github.com/fuseml/extensions/tree/main/installer) includes a variety of AI/ML tools that can be installed through the FuseML installer. The repository is maintained by the FuseML team and is updated regularly.
+
+## Installer Extensions
+
+An installer extension is represented by a `description.yaml` YAML file that provides a description of the operations that are needed to install and uninstall a third-party application. The installer extensions are designed to be used with cloud-native applications that can be deployed in a Kubernetes cluster, but they can also be used with other types of infrastructures and deployment models.
+
+The following is an example of an installer extension descriptor defined for KServe:
+
+```yaml
+name: kserve
+product: kserve
+version: "0.7.0"
+description: |
+  Serverless Inferencing on Kubernetes
+requires:
+  - knative
+  - cert-manager
+install:
+  - type: manifest
+    location: https://github.com/kserve/kserve/releases/download/v0.7.0/kserve.yaml
+    waitfor:
+      - namespace: kserve
+        selector: control-plane=kserve-controller-manager
+  - type: kustomize
+    location: kustomize
+    waitfor:
+      - namespace: kserve
+        selector: app.kubernetes.io/component=kserve-models-web-app
+uninstall:
+  - type: kustomize
+    location: kustomize
+  - type: manifest
+    location: https://github.com/kserve/kserve/releases/download/v0.7.0/kserve.yaml
+services:
+  - id: API
+    resource: kserve-api
+    category: prediction-serving
+    description: kserve prediction service API
+    endpoints:
+      - url: http://kubernetes.default.svc
+        type: internal
+  - id: UI
+    resource: kserve-ui
+    category: UI
+    description: KServe UI
+gateways:
+  - name: kserve-web-app
+    namespace: kserve
+    servicehost: kserve-models-web-app
+    port: 80
+rolerules:
+  - apigroups:
+      - serving.kserve.io
+    resources:
+      - inferenceservices
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+      - watch
+```
+
+The descriptor specifies a list of installation and un-installation steps, such as Kubernetes manifests and Kustomize files, that have to be executed in order to deploy the application or to subsequently remove it from a Kubernetes cluster. The other fields in the descriptor are used to describe the application, its capabilities and its permission requirements.
+
+The extension descriptor is broken down into sections and explored piece by piece in the following paragraphs.
+
+```yaml
+name: kserve
+product: kserve
+version: "0.7.0"
+description: |
+  Serverless Inferencing on Kubernetes
+[...]
+```
+
+This part is self explanatory. The `name` field is the extension identifier that along with the `product`, `version` and `description` fields is used to populate the [Extension Record](extension-registry.md#extension-records) that FuseML will use to register KServe as an extension in the [FuseML Extension Registry](extension-registry.md) after installation.
+
+```yaml
+[...]
+requires:
+  - knative
+  - cert-manager
+[...]
+```
+
+Extensions can depend on other extensions. If a description file contains a `requires` field, the value is expected to be a list of names of other extensions that are considered requirements for the current one. The FuseML installer will take care to install all dependencies in the right order, so they do not need to be explicitly listed on the command line.
+
+```yaml
+[...]
+install:
+  - type: manifest
+    location: https://github.com/kserve/kserve/releases/download/v0.7.0/kserve.yaml
+    waitfor:
+      - namespace: kserve
+        selector: control-plane=kserve-controller-manager
+  - type: kustomize
+    location: kustomize
+    waitfor:
+      - namespace: kserve
+        selector: app.kubernetes.io/component=kserve-models-web-app
+uninstall:
+  - type: kustomize
+    location: kustomize
+  - type: manifest
+    location: https://github.com/kserve/kserve/releases/download/v0.7.0/kserve.yaml
+[...]
+```
+
+The `install` and `uninstall` sections list the steps necessary to install, configure and uninstall the extension. KServe is installed through a combination of Kubernetes manifests and Kustomize files. The following types of installation mechanisms are currently supported:
+
+- `helm` - helm chart
+- `manifest` - plain Kubernetes manifest, to be installed using `kubectl`. All information is expected to be present in the manifest file.
+- `kustomize` - Kustomize deployment. It can be a URL (i.e. one that works as an input for `kubectl -k`) or an absolute or relative path to a local directory with Kustomize files.
+- `script` - manage the installation/uninstallation through shell scripts. Specific `install` and `uninstall` actions need to be provided by way of referencing specific shell scripts.
+
+Location arguments can be configured for every type of step to point to external resources, such as helm charts, Kubernetes manifests, Kustomize directories and shell scripts:
+
+- `location`: could be either a URL or a local path relative to the extension directory. If used together with a helm chart, `location` needs to point to tarball with the chart.
+- `repo`, `chart` and `version`: specific to helm charts only. `repo` is the chart repository from which the chart with `chart` name and the `version` version should be installed. To use this combination, the `location` field must be empty.
+- `values`: points to a customized `values.yaml` file used in combination with a helm chart. Just like `location`, it can be a URL or a local path.
+
+Each step can have its own `namespace` explicitly configured. If omitted, the global `namespace` attribute is used. If this is also missing or empty, the FuseML installer will not use any namespace during the step operation.
+
+After the instruction from an installation step is executed, it is sometimes wise to wait until a certain condition is met to make sure the installer may continue to the next step. The `waitfor` section may be used to indicate a specific condition the installer should wait for. It takes the arguments that could generally be passed to `kubectl wait` command.
+The currently supported arguments are:
+
+- `kind` (if missing, defaults to `pod`)
+- `namespace`
+- `condition` (defaults to `ready`)
+- `timeout` (in seconds; defaults to 300)
+- `selector`. If the value of `selector` is `all`, FuseML will wait for all resources of given `kind` to reach the indicated `condition`. Otherwise, the `selector` value is treated like the value for the `--selector` option for the `kubectl wait` command.
+
+```yaml
+[...]
+services:
+  - id: API
+    resource: kserve-api
+    category: prediction-serving
+    description: kserve prediction service API
+    endpoints:
+      - url: http://kubernetes.default.svc
+        type: internal
+  - id: UI
+    resource: kserve-ui
+    category: UI
+    description: KServe UI
+[...]
+```
+
+The `services` section provides information that is reflected in the generated Extension Descriptor that FuseML will use to register the extension in the [FuseML Extension Registry](extension-registry.md), more specifically in the `services` field of the Extension Record. For more information about the fields that can be configured in the services section, see [Extension Descriptor](extension-registry.md#extension-records).
+
+!!! note
+
+    The `services` field should only be configured for extensions that expose APIs that need to be accessed from the FuseML workflows. Extensions that are not meant to interact with FuseML workflows (e.g. those that are only used as functional dependencies for other extensions) do not need to have this field filled in and will be ignored by FuseML in relation with workflows.
+
+```yaml
+[...]
+gateways:
+  - name: kserve-web-app
+    namespace: kserve
+    servicehost: kserve-models-web-app
+    port: 80
+[...]
+```
+
+Some Kubernetes applications such as KServe don't include means of exposing the provided services in their official deployment manifests (e.g. Ingress, Load Balancer or Istio Gateway). When the `gateways` field is specified in the descriptor, the FuseML installer will also create one Istio gateway corresponding to each entry.
+
+```yaml
+[...]
+rolerules:
+  - apigroups:
+      - serving.kserve.io
+    resources:
+      - inferenceservices
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+      - watch
+```
+
+Some third party AI/ML services, like KServe, come in the form of Kubernetes operators that have associated CRD. To have access to these resources, the workflow steps need to have additional permissions granted to them. The `rolerules` section can be used to provide the list of permissions (Kubernetes roles) that need to be granted to FuseML workflow steps that need to access the extension. The syntax is the same as for the [Kubernetes Role object](https://kubernetes.io/docs/reference/access-authn-authz/rbac/), i.e. it is expected to contain ApiGroups, Resources and Verbs values.
+
+!!! note
+
+    All steps in a FuseML workflow are executed in the `fuseml-workloads` Kubernetes namespace and in the context of the `fuseml-workloads` service account. For 3rd party tools that are not installed using installer extensions, or that do not include `rolerules` in the extension descriptor, the admin must manually add the required permissions to the `fuseml-workloads` service account. FuseML automatically adds the permissions listed in the `rolerules` section to the mentioned service account.
+
+For more examples of extension descriptors and how to build them, take a look at the [Installer Extension Repository maintained by the FuseML team](https://github.com/fuseml/extensions/tree/main/installer)
+
+## Installer Extension Repository
+
+Installer extensions have to be organized using a particular directory structure to be recognized by the FuseML installer. A FuseML installer extension repository is a directory (local or remote) containing description files of extensions. Each extension has its own subdirectory that matches the extension name. Mandatory component under each extension subdirectory is the `description.yaml` file.
+
+Example directory structure:
+
+```
+extensions
+  - mlflow
+    - description.yaml
+    - values.yaml
+  - knative
+    - description.yaml
+    - install.sh
+    - uninstall.sh
+```
+
+The FuseML installer defaults to using the [Installer Extension Repository maintained by the FuseML team](https://github.com/fuseml/extensions/tree/main/installer). To point it to a different location, the optional `--extension-repository` command line argument can be used.
+
+
+
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,11 @@ Well, it depends on what you would you like to do:
 
 - if you want to find out more about this project and the problems it aims to solve, proceed to the [About](about.md) section.
 - if you are looking to learn about FuseML capabilities, we suggest to take the [Quick Start](quickstart.md).
-- if you want to learn more about FuseML workflows and available workflow extensions, consult the [Workflows](workflows/workflows.md) section.
+- if you want to learn more about FuseML's core concepts, use one of the following resources:
+
+  - the [Workflows](workflows/workflows.md) section covers FuseML workflows and available workflow extensions
+  - the [Extension Registry](extensions/extension-registry.md) section describes in more detail how FuseML integrates with 3rd party AI/ML services
+
 - if you are evaluating becoming a contributor to this project, go straight to [Contributing](CONTRIBUTING.md) section.
 
 ## Demo video

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,8 @@ We follow 5 simple principles
 Well, it depends on what you would you like to do:
 
 - if you want to find out more about this project and the problems it aims to solve, proceed to the [About](about.md) section.
-- if you are looking to learn about FuseML capabilites, we suggest to take the [Quick Start](quickstart.md).
+- if you are looking to learn about FuseML capabilities, we suggest to take the [Quick Start](quickstart.md).
+- if you want to learn more about FuseML workflows and available workflow extensions, consult the [Workflows](workflows/workflows.md) section.
 - if you are evaluating becoming a contributor to this project, go straight to [Contributing](CONTRIBUTING.md) section.
 
 ## Demo video

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,8 +27,9 @@ Well, it depends on what you would you like to do:
 - if you are looking to learn about FuseML capabilities, we suggest to take the [Quick Start](quickstart.md).
 - if you want to learn more about FuseML's core concepts, use one of the following resources:
 
-  - the [Workflows](workflows/workflows.md) section covers FuseML workflows and available workflow extensions
-  - the [Extension Registry](extensions/extension-registry.md) section describes in more detail how FuseML integrates with 3rd party AI/ML services
+    - the [Workflows](workflows/workflows.md) section covers FuseML workflows and available workflow extensions
+    - the [Extension Registry](extensions/extension-registry.md) section describes in more detail how FuseML integrates with 3rd party AI/ML services
+    - the [Installer Extensions](extensions/installer-extensions.md) section details how FuseML can be used to deploy and manage entire AI/ML tool stacks constructed out of 3rd party AI/ML tools 
 
 - if you are evaluating becoming a contributor to this project, go straight to [Contributing](CONTRIBUTING.md) section.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -106,4 +106,4 @@ kubectl get pods -n tekton-pipelines -o wide
 kubectl get pods -n fuseml-core -o wide
 ```
 
-If everything is in running or completed status, you are good to go. Continue on to the [tutorial](tutorials/kserve-basic.md) section and start to have fun with FuseML.
+If everything is in running or completed status, you are good to go. Continue with one of the available tutorials, such as the [MLFlow and KServe basic example](tutorials/kserve-basic.md) and start to have fun with FuseML.

--- a/docs/tutorials/openvino-extensions.md
+++ b/docs/tutorials/openvino-extensions.md
@@ -32,7 +32,7 @@ The [Extension Registry](../extensions/extension-registry.md) section covers det
 
 ### FuseML Workflows
 
-FuseML workflows are automation processes built out of individual, reusable steps, connected together to form a pipeline. Each step is represented by a container image that implements a particular function in the MLOps lifecycle. Workflow steps can also be thought of as integration mechanisms, especially if they connect to 3rd party services and/or act as adapters for 3rd party APIs. FuseML already features [a collection of workflow step container images](https://github.com/fuseml/extensions/tree/main/images) that implement a variety of ML functions, such as training and serving ML models. 
+FuseML workflows are automation processes built out of individual, reusable steps, connected together to form a pipeline. Each step is represented by a container image that implements a particular function in the MLOps lifecycle. Workflow steps can also be thought of as integration mechanisms, especially if they connect to 3rd party services and/or act as adapters for 3rd party APIs. FuseML already features [a collection of workflow step container images](https://github.com/fuseml/extensions/tree/release-0.3/images) that implement a variety of ML functions, such as training and serving ML models. 
 
 The [FuseML Workflows](../workflows/workflows.md) section covers detailed information about workflows and workflow extensions.
 

--- a/docs/tutorials/openvino-extensions.md
+++ b/docs/tutorials/openvino-extensions.md
@@ -21,8 +21,7 @@ The FuseML installer can be tasked with installing more than just the FuseML cor
 
 With FuseML Installer Extensions, users can build installation shortcuts to quickly deploy their own AI/ML tool stack, or reuse one or more of the AI/ML tools already featured in the default [FuseML Installer Extension Repository](https://github.com/fuseml/extensions/tree/main/installer), including but not limited to: MLFlow, KServe and Seldon Core.
 
-The [Installation of ML Extensions](https://github.com/fuseml/fuseml/blob/main/docs/blueprints/001-installation-of-extensions.md) blueprint has detailed information about this feature and how it can be used to extend the installer to cover additional AI/ML tools and services.
-
+The [Installer Extensions](../extensions/installer-extensions.md) section contains detailed information about this extensibility feature and how it can be used to extend the installer to cover additional AI/ML tools and services.
 ### FuseML Extension Registry
 
 The FuseML Extension Registry is basically a database storing information about external AI/ML services and APIs that can be consumed in FuseML workflows. Specifically, each entry in the Extension Registry represents a particular instance of an external AI/ML service or API, and contains information about how it can be accessed (e.g. URLs, endpoints, client configuration and credentials) as well as what specialized roles it can play in the MLOps reference architecture (e.g. data store, model store, prediction platform, experiment tracking, distributed model training etc.).

--- a/docs/tutorials/openvino-extensions.md
+++ b/docs/tutorials/openvino-extensions.md
@@ -29,11 +29,13 @@ The FuseML Extension Registry is basically a database storing information about 
 
 Registering AI/ML services and APIs with the FuseML Extension Registry allows them to be discovered, accessed and consumed in FuseML workflows. This approach decouples FuseML workflows from the actual back-ends used to execute individual steps and enables users to configure MLOps workflows that are portable and reusable. The Extension Registry API is flexible enough to allow FuseML admins to register any 3rd party AI/ML tool. In addition, [FuseML Installer Extensions](#fuseml-installer-extensions) can be used not only to install AI/ML tools, but also to automatically register them with the FuseML Extension Registry.
 
-The [Extension Registry](https://github.com/fuseml/fuseml/blob/main/docs/blueprints/003-extension-registry.md) blueprint covers detailed information about this extensibility mechanism.
+The [Extension Registry](../extensions/extension-registry.md) section covers detailed information about this extensibility mechanism.
 
 ### FuseML Workflows
 
-FuseML workflows are automation processes built out of individual, reusable steps, connected together to form a pipeline. Each step is represented by a container image that implements a particular function in the MLOps lifecycle. Workflow steps can also be thought of as integration mechanisms, especially if they connect to 3rd party services and/or act as adapters for 3rd party APIs. FuseML already features [a collection of workflow step container images](https://github.com/fuseml/extensions/tree/main/images) that implement a variety of ML functions, such as training and serving ML models.
+FuseML workflows are automation processes built out of individual, reusable steps, connected together to form a pipeline. Each step is represented by a container image that implements a particular function in the MLOps lifecycle. Workflow steps can also be thought of as integration mechanisms, especially if they connect to 3rd party services and/or act as adapters for 3rd party APIs. FuseML already features [a collection of workflow step container images](https://github.com/fuseml/extensions/tree/main/images) that implement a variety of ML functions, such as training and serving ML models. 
+
+The [FuseML Workflows](../workflows/workflows.md) section covers detailed information about workflows and workflow extensions.
 
 ## OpenVINO Overview
 

--- a/docs/tutorials/openvino-mlflow.md
+++ b/docs/tutorials/openvino-mlflow.md
@@ -72,7 +72,7 @@ $ fuseml-installer install
 
 Configuration...
   🧭  system_domain: 
-  🧭  extensions_repository: https://raw.githubusercontent.com/fuseml/extensions/main/installer/
+  🧭  extensions_repository: https://raw.githubusercontent.com/fuseml/extensions/release-0.3/installer/
   🧭  force_reinstall: false
 
 🚢 Deploying Istio.....
@@ -206,7 +206,7 @@ $ fuseml extension list
 We will be training a
 [Convolutional Neural Network (CNN)](https://developers.google.com/machine-learning/glossary/#convolutional_neural_network)
 to classify [CIFAR-10 images](https://www.cs.toronto.edu/~kriz/cifar.html) using the Keras Sequential API.
-The complete original code for the model training is available [here](https://github.com/fuseml/examples/tree/main/codesets/mlflow/keras). The code we're using in this tutorial is a modified version of the original: the model architecture has been slightly changed, to make the model converge faster and to yield better results, based on recommendations from [this Machine Learning Mastery article](https://machinelearningmastery.com/how-to-develop-a-cnn-from-scratch-for-cifar-10-photo-classification/).
+The complete original code for the model training is available [here](https://github.com/fuseml/examples/tree/release-0.3/codesets/mlflow/keras). The code we're using in this tutorial is a modified version of the original: the model architecture has been slightly changed, to make the model converge faster and to yield better results, based on recommendations from [this Machine Learning Mastery article](https://machinelearningmastery.com/how-to-develop-a-cnn-from-scratch-for-cifar-10-photo-classification/).
 
 ### Training & Serving using FuseML
 

--- a/docs/workflows/kserve-predictor.md
+++ b/docs/workflows/kserve-predictor.md
@@ -1,0 +1,24 @@
+# KServe predictor extension for FuseML workflows
+
+## Overview
+
+The KServe predictor workflow step can be used to create and manage [KServe prediction services](https://kserve.github.io/website/) to serve input ML models as part of the execution of FuseML workflows. The KServe predictor is designed to work primarily with the following types of ML models that are trained and saved using the MLflow library:
+
+- scikit-learn pickled models
+- TensorFlow (saved_model) models
+- ONNX models
+
+The KServe predictor step expects a model URL to be supplied as input, pointing to the location in an MLflow artifact store where the model is stored. Currently, S3 is the only protocol supported for the MLflow artifact store back-end.
+
+The predictor performs the following tasks:
+
+- downloads the model locally from the MLflow artifact store
+- if so instructed, it auto-detects the model format based on the information stored in the MLflow artifact store and decides which KServe predictor engine to use for it. Otherwise, it validates the model format against the type of predictor engine specified as input.
+- it performs some minor conversion tasks required to adapt the input MLflow model directory layout to the one required by KServe
+- it creates a KServe prediction service to serve the model
+- finally, it registers the KServe prediction service with FuseML as an Application object. Information about the Application, such as the type and exposed inference URL can be retrieved at any time using the FuseML API and CLI.
+
+## Using the KServe Predictor Step
+
+TBD
+

--- a/docs/workflows/mlflow-builder.md
+++ b/docs/workflows/mlflow-builder.md
@@ -1,0 +1,148 @@
+# MLflow runtime environment builder extension for FuseML workflows
+
+## Overview
+
+The [MLFlow Project format](https://www.mlflow.org/docs/latest/projects.html) is a flexible way of configuring how to package and execute python ML code in a reproducible way. It allows developers to declaratively specify python package requirements and code execution entry points.
+
+The MLflow builder workflow step leverages the MLflow Project conventions to automate building MLflow runtime environments: container images used for the execution of MLflow augmented python code within a FuseML workflow. The MLflow builder works with any codeset that meets the following requirements and conventions:
+
+- an `MLproject` file is present the codeset's root directory
+- python requirements are specified using a `conda.yaml` file or a `requirements.txt` file, also present in the codeset's root directory
+- the `MLproject` file describes one or more entry points for the codeset's python code, as well as a list of parameters that are passed to the entry points. The entry points are specified using the `entry_points` key in the `MLproject` file. At a minimum, a `main` entrypoint is required, which will be used as the default entry point when executing the codeset code, unless overridden by workflow input parameters. An example `MLproject` file and a corresponding `conda.yaml` file are shown below:
+
+    ```yaml
+    name: my_keras_model
+    conda_env: conda.yaml
+    entry_points:
+      main:
+        parameters:
+          epochs: {type: int, default: 2}
+          batch_size: {type: int, default: 64}
+        command: "python train.py --epochs={epochs} --batch_size={batch_size}"
+    ```
+
+    ```yaml
+    name: my_test_env
+    channels:
+      - conda-forge
+    dependencies:
+      - python=3.6
+      - pip
+      - pip:
+        - mlflow
+        - tensorflow==2.0.0
+    ```
+
+The MLflow builder has a single output: the container registry repository and the image tag where the built MLflow environment container image is stored. This output can be used in subsequent workflow steps to run the MLflow code from the same codeset as the one used as input. The most common use for the resulted container image is executing code that trains and validates ML models. For this reason, the output container image is often referred to as a "trainer" workflow step.
+
+## Using the MLflow Builder Step
+
+Here is an example of a FuseML workflow that builds an MLflow runtime environment container image out of an MLflow compatible codeset and returns the location where it's stored in the internal FuseML container registry:
+
+```yaml
+name: build_mlflow_env
+description: |
+  Example workflow that builds a MLflow environment container image
+  out of an MLflow compatible codeset."
+inputs:
+  - name: mlflow-codeset
+    description: an MLFlow compatible codeset
+    type: codeset
+outputs:
+  - name: mlflow-runtime-image
+    description: "The location of the built MLflow runtime environment container image."
+    type: string
+steps:
+  - name: builder
+    image: ghcr.io/fuseml/mlflow-builder:latest
+    inputs:
+      - name: mlflow-codeset
+        codeset:
+          name: '{{ inputs.mlflow-codeset }}'
+          path: /project
+    outputs:
+      - name: mlflow-runtime-image
+```
+
+Aside from the mandatory codeset input, the MLflow builder workflow step also accepts the following optional input parameters that can be used to customize how the ML python environment container image is being built and published:
+
+- `registry` - the container registry hostname that is used by the builder step when pushing the built MLflow environment image to the container registry. The default value is `registry.fuseml-registry`, which points to the FuseML builtin container registry. 
+- `pull_registry` - the container registry hostname used by consumers that need to pull the built MLflow environment image (e.g. the container runtime instances running on the Kubernetes cluster nodes where the FuseML workflow is executed). In most cases, this is the same as the `registry` parameter. However, sometimes, this value needs to be different than `registry`, for example when the container registry is accessed through different endpoints by the builder step and by the kubernetes cluster itself. In particular, when using the default internal FuseML registry, we need to reference the repository using the node's localhost address (see https://github.com/fuseml/fuseml/issues/65). The default value is `127.0.0.1:30500`, which is how the FuseML builtin container registry is exposed internally to the Kubernetes cluster. If not set, or set to an empty value, the `registry` parameter value will be used instead.
+- `repository` - the container registry repository name that is used by the builder step when pushing the built MLflow environment image to the container registry. The default value is `mlflow/trainer`.
+- `miniconda_version` - the version (tag) of the `continuumio/miniconda3` base container image to use when building MLflow environment container images based on conda (i.e. when a `conda.yaml` file is included in the codeset). If not specified, the builder will default to `4.10.3`.
+- `base_image` - the base image to use when building MLflow environment container images based on pip (i.e. when a pip `requirements.txt` file is included in the codeset). If not specified, the builder will default to `python:3.6.13`.
+- `verbose` - set to `true` to enable verbose logging in the builder workflow step (default is `false`).
+- `compressed_caching` - use this parameter to control the compressed caching feature used by [Kaniko](https://github.com/GoogleContainerTools/kaniko) when building container images. Compressed caching is set to false by default to reduce memory usage with larger images and avoid OOM problems. Set this flag to true to enable compressed caching and reduce the image build time.
+
+
+## Using the MLflow Runtime Environment Step
+
+The container image built by the MLflow builder workflow step can itself be used as a FuseML workflow step. The same codeset used as input for the MLflow builder must be supplied as input to the MLflow runtime environment. The MLflow runtime environment workflow step executes the MLflow code present in the codeset and returns the URL where one or more MLflow artifacts are stored during the execution. Depending on how the MLflow code is configured to run, this can be a local path or a URL pointing to a remote MLflow artifact store.
+
+The MLflow runtime environment container image also accepts the following optional workflow input parameters that can be used to customize how the MLflow code is executed:
+
+- `mlflow_experiment` - the experiment ID to use when running the MLflow code. If not specified, the experiment name is derived from the codeset name and project used as input
+- `mlflow_entrypoint` - controls which of the MLflow entrypoints configured in the `MLproject` file used to build the image is executed. If not specified, `main` is used as the default entrypoint.
+- `mlflow_entrypoint_args` - space or comma-separated list of additional MLflow run entrypoint arguments in the form `name=value`. These arguments are passed to the MLflow entrypoint as keyword arguments. For example, a value of `epochs=2,batch_size=64` will pass the arguments `epochs=2` and `batch_size=64` to the MLflow entrypoint.
+- `mlflow_artifact_path` - sub-path under the MLflow artifact repository that should be returned as output. By default, the `model` sub-directory is returned, because this is where MLflow stores the ML models.
+- `verbose` - set to `true` to enable verbose logging in the MLflow runtime step (default is `false`).
+
+The MLflow runtime workflow step can also take in additional environment variables that are passed transparently to the MLflow runtime and used to configure how the MLflow runtime can access a remote MLflow tracking server and artifact store. For more information on what variables are available and how they can be used, please refer to the [relevant section in the official MLflow documentation](https://www.mlflow.org/docs/latest/tracking.html#logging-to-a-tracking-server). Only a subset of the available variables are listed here:
+
+!!! note
+
+    Some of these environment variables contain sensitive data, such as keys and passwords and should not be explicitly configured as workflow step env vars. Instead, they should be configured in the FuseML Extension Registry and only referenced in the FuseML workflows as extension requirements.
+
+- `MLFLOW_TRACKING_URI` - the URL of a remote MLflow tracking server to use.
+- `MLFLOW_TRACKING_USERNAME` and `MLFLOW_TRACKING_PASSWORD` - username and password to use with HTTP Basic authentication to authenticate with the remote MLflow tracking server.
+- `MLFLOW_S3_ENDPOINT_URL` - store artifacts in a custom S3 compatible artifact store (e.g. minio)
+- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` - credentials for a AWS S3 and S3-compatible artifact store
+
+The recommended way to use an MLflow runtime step in a FuseML workflow is to have the MLflow builder step part of the same workflow and to reference its output as input to the MLflow runtime step, as shown in the example below. The MLflow builder workflow step is optimized to skip rebuilding the MLflow runtime environment container image during subsequent workflow executions if the software requirements haven't changed.
+
+```yaml
+name: train_mlflow_model
+description: |
+  Example workflow that builds a MLflow environment container image
+  out of an MLflow compatible codeset and then uses it to run the MLflow
+  code in the codeset to train and save a ML model."
+inputs:
+  - name: mlflow-codeset
+    description: an MLFlow compatible codeset
+    type: codeset
+outputs:
+  - name: model-url
+    description: "The URL where the model is saved in the MLflow artifact store."
+    type: string
+steps:
+  - name: builder
+    image: ghcr.io/fuseml/mlflow-builder:latest
+    inputs:
+      - name: mlflow-codeset
+        codeset:
+          name: '{{ inputs.mlflow-codeset }}'
+          path: /project
+    outputs:
+      - name: mlflow-runtime
+  - name: trainer
+    image: "{{ steps.builder.outputs.image }}"
+    inputs:
+      - name: mlflow-codeset
+        codeset:
+          name: "{{ inputs.mlflow-codeset }}"
+          path: "/project"
+    outputs:
+      - name: model-url
+    extensions:
+      - name: mlflow-tracking
+        product: mlflow
+        service_resource: mlflow-tracking
+      - name: mlflow-store
+        product: mlflow
+        service_resource: s3
+```
+
+Note how the `builder` step output is referenced as the image value for the `trainer` step and how both steps use the same `mlflow-codeset` codeset as input. The builder workflow step creates the MLflow environment container image and the trainer step uses it to execute the MLflow code and train the ML model.
+
+Also observe how the `mlflow-tracking` and `mlflow-store` extensions are used in the `trainer` step to reference an MLflow tracking server and an artifact store backend configured in the FuseML Extension Registry. This avoids having to configure credentials and other environment variables explicitly in the FuseML workflow. The FuseML workflow engine automatically resolves these references to matching records available in the FuseML Extension Registry and passes the configuration entries in the extension records as environment variables to the workflow step container (i.e. variables like `MLFLOW_TRACKING_URI` , `MLFLOW_S3_ENDPOINT_URL`, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`).
+

--- a/docs/workflows/ovms-converter.md
+++ b/docs/workflows/ovms-converter.md
@@ -1,0 +1,28 @@
+# OpenVINO Model Server converter extension for FuseML workflows
+
+## Overview
+
+The OVMS converter workflow step can be used to convert input ML models to the IR (Intermediate Representation) format supported by the [OpenVINO Model Server](https://docs.openvino.ai/latest/openvino_docs_ovms.html). It is normally used in combination with the [OVMS predictor workflow step](ovms-predictor.md) in FuseML workflows to serve input ML models with the OpenVINO Model Server. The OVMS converter workflow extension is implemented using the [OpenVINO Model Optimizer](https://docs.openvino.ai/latest/openvino_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
+
+The OVMS converter step expects a model URL to be supplied as input, pointing to the location in a remote model store where the model is stored. The protocols currently supported for the remote artifact store are: 
+
+- AWS S3 or S3 compatible
+- GCS
+- plain HTTP/HTTPs remote location
+
+The model formats of the input models that the OVMS converter is able to convert into IR format are:
+
+- TensorFlow (saved_model) models
+- ONNX models
+
+The converter performs the following tasks:
+
+- downloads the model locally from the remote artifact store.
+- if the model is stored in an MLflow remote store and if so instructed, it auto-detects the format of the input model based on the information stored in the MLflow artifact store.
+- it converts/optimizes the model using the provided OpenVINO Model Optimizer tools.
+- it uploads the converted model to the output remote artifact store.
+
+## Using the OVMS Converter Step
+
+TBD
+

--- a/docs/workflows/ovms-predictor.md
+++ b/docs/workflows/ovms-predictor.md
@@ -1,0 +1,21 @@
+# OpenVINO Model Server predictor extension for FuseML workflows
+
+## Overview
+
+The OVMS predictor workflow step can be used to create and manage [OpenVINO Model Server inference servers](https://docs.openvino.ai/latest/openvino_docs_ovms.html) to serve input ML models as part of the execution of FuseML workflows. The OVMS predictor only accepts models in IR (Intermediate Representation) format as input. The [OVMS converter](ovms-converter.md) workflow extension can be used to convert models to IR format.
+
+The KServe predictor step expects a model URL to be supplied as input, pointing to the location in a remote model store where the model is stored. The protocols supported for the remote artifact store are the same as [those supported by the OVMS implementation](https://github.com/openvinotoolkit/model_server/tree/v2021.3/deploy#model-repository): 
+
+- AWS S3 or S3 compatible
+- GCS
+- Azure Blob Storage
+
+The predictor performs the following tasks:
+
+- it creates an OVMS prediction service instance to serve the model, and an Istio virtualservice that exposes the prediction service
+- it registers the OVMS prediction service with FuseML as an Application object. Information about the Application, such as the type and exposed inference URL can be retrieved at any time using the FuseML API and CLI.
+
+## Using the OVMS Predictor Step
+
+TBD
+

--- a/docs/workflows/seldon-core-predictor.md
+++ b/docs/workflows/seldon-core-predictor.md
@@ -1,0 +1,24 @@
+# Seldon Core predictor extension for FuseML workflows
+
+## Overview
+
+The Seldon Core predictor workflow step can be used to create and manage [Seldon Core prediction services](https://docs.seldon.io/projects/seldon-core/en/latest/) to serve input ML models as part of the execution of FuseML workflows. The Seldon Core predictor is designed to work primarily with the following types of ML models that are trained and saved using the MLflow library:
+
+- scikit-learn pickled models
+- TensorFlow (saved_model) models
+- ONNX models
+
+The Seldon Core predictor step expects a model URL to be supplied as input, pointing to the location in an MLflow artifact store where the model is stored. Currently, S3 is the only protocol supported for the MLflow artifact store back-end.
+
+The predictor performs the following tasks:
+
+- downloads the model locally from the MLflow artifact store
+- if so instructed, it auto-detects the model format based on the information stored in the MLflow artifact store and decides which type of Seldon Core predictor server to use for it. Otherwise, it validates the model format against the type of predictor server specified as input.
+- it performs some minor conversion tasks required to adapt the input MLflow model directory layout to the one required by Seldon Core
+- it creates a Seldon Core prediction service to serve the model
+- finally, it registers the Seldon Core prediction service with FuseML as an Application object. Information about the Application, such as the type and exposed inference URL can be retrieved at any time using the FuseML API and CLI.
+
+## Using the Seldon Core Predictor Step
+
+TBD
+

--- a/docs/workflows/workflows.md
+++ b/docs/workflows/workflows.md
@@ -4,7 +4,7 @@ FuseML workflows are automation processes built out of individual, reusable step
 
 Workflow steps can also be thought of as integration mechanisms, especially if they connect to 3rd party services and/or act as adapters for 3rd party APIs. FuseML already features [a collection of workflow step container images](#fuseml-workflow-extensions) that implement a variety of ML functions, such as training and serving ML models.
 
-FuseML workflows are configured using a declarative YAML syntax. The following is a simple example of a workflow that trains a model and then serves it. More workflow examples can be found in the [FuseML examples repository](https://github.com/fuseml/examples/tree/main/workflows).
+FuseML workflows are configured using a declarative YAML syntax. The following is a simple example of a workflow that trains a model and then serves it. More workflow examples can be found in the [FuseML examples repository](https://github.com/fuseml/examples/tree/release-0.3/workflows).
 
 
 ```yaml
@@ -186,7 +186,7 @@ The third and final step in the workflow is responsible for creating a KServe pr
 
 ## FuseML Workflow Extensions
 
-A set of container images implementing various workflow extensions are maintained by the FuseML team. If you are interested in using a specific workflow extension, you can find the container image implementing it in the [FuseML extensions repository](https://github.com/fuseml/extensions/tree/main/images). They can be used in FuseML workflows to easily integrate with 3rd party tools and services providing features like ML experiment tracking, artifact storage, prediction services, and more: 
+A set of container images implementing various workflow extensions are maintained by the FuseML team. If you are interested in using a specific workflow extension, you can find the container image implementing it in the [FuseML extensions repository](https://github.com/fuseml/extensions/tree/release-0.3/images). They can be used in FuseML workflows to easily integrate with 3rd party tools and services providing features like ML experiment tracking, artifact storage, prediction services, and more: 
 
 - [MLFlow builder](mlflow-builder.md) - builds python runtime environment container images for codesets that are structured according to the [MLFlow Project format](https://www.mlflow.org/docs/latest/projects.html).
 - [KServe predictor](kserve-predictor.md) - deploys models using the [KServe inference platform](https://kserve.github.io/website/).

--- a/docs/workflows/workflows.md
+++ b/docs/workflows/workflows.md
@@ -1,0 +1,195 @@
+# FuseML Workflows
+
+FuseML workflows are automation processes built out of individual, reusable steps, connected together to form a pipeline. They are a way to automate the process of creating and deploying ML models. Running a workflow results in launching a number of jobs and services that are created and executed in the correct order to produce the desired outputs. Each step in a workflow is represented by a container image that implements a particular function in the MLOps lifecycle.
+
+Workflow steps can also be thought of as integration mechanisms, especially if they connect to 3rd party services and/or act as adapters for 3rd party APIs. FuseML already features [a collection of workflow step container images](#fuseml-workflow-extensions) that implement a variety of ML functions, such as training and serving ML models.
+
+FuseML workflows are configured using a declarative YAML syntax. The following is a simple example of a workflow that trains a model and then serves it. More workflow examples can be found in the [FuseML examples repository](https://github.com/fuseml/examples/tree/main/workflows).
+
+
+```yaml
+name: mlflow-e2e
+description: |
+  End-to-end pipeline template that takes in an MLFlow compatible codeset,
+  runs the MLFlow project to train a model, then creates a KServe prediction
+  service that can be used to run predictions against the model.
+inputs:
+  - name: mlflow-codeset
+    description: an MLFlow compatible codeset
+    type: codeset
+  - name: predictor
+    description: type of predictor engine
+    type: string
+    default: auto
+outputs:
+  - name: prediction-url
+    description: "The URL where the exposed prediction service endpoint can be contacted to run predictions."
+    type: string
+steps:
+  - name: builder
+    image: ghcr.io/fuseml/mlflow-builder:v0.3.0
+    inputs:
+      - name: mlflow-codeset
+        codeset:
+          name: "{{ inputs.mlflow-codeset }}"
+          path: /project
+    outputs:
+      - name: image
+  - name: trainer
+    image: "{{ steps.builder.outputs.image }}"
+    inputs:
+      - name: mlflow-codeset
+        codeset:
+          name: "{{ inputs.mlflow-codeset }}"
+          path: "/project"
+    outputs:
+      - name: mlflow-model-url
+    extensions:
+      - name: mlflow-tracking
+        product: mlflow
+        service_resource: mlflow-tracking
+      - name: mlflow-store
+        product: mlflow
+        service_resource: s3
+  - name: predictor
+    image: ghcr.io/fuseml/kserve-predictor:v0.3.0
+    inputs:
+      - name: model
+        value: "{{ steps.trainer.outputs.mlflow-model-url }}"
+      - name: predictor
+        value: "{{ inputs.predictor }}"
+      - name: mlflow-codeset
+        codeset:
+          name: "{{ inputs.mlflow-codeset }}"
+          path: "/project"
+    outputs:
+      - name: prediction-url
+    extensions:
+      - name: s3-storage
+        service_resource: s3
+      - name: kserve
+        service_resource: kserve-api
+```
+
+Let's analyze the workflow definition section by section and explore what it all means.
+
+
+```yaml
+name: mlflow-e2e
+description: |
+  End-to-end pipeline template that takes in an MLFlow compatible codeset,
+  runs the MLFlow project to train a model, then creates a KServe prediction
+  service that can be used to run predictions against the model.
+```
+
+The workflow `name` is used to identify the workflow in all subsequent workflow operations, such as assigning codesets to it or listing its executions. The `description` is used to describe the workflow.
+
+```yaml
+inputs:
+  - name: mlflow-codeset
+    description: an MLFlow compatible codeset
+    type: codeset
+  - name: predictor
+    description: type of predictor engine
+    type: string
+    default: auto
+outputs:
+  - name: prediction-url
+    description: "The URL where the exposed prediction service endpoint can be contacted to run predictions."
+    type: string
+```
+
+This is where the workflow's global parameters, inputs and outputs are declared. Currently, the only type of supported input for FuseML workflows and steps is the codeset. In this example:
+
+- the `mlflow-codeset` input is a codeset that contains python code that will be executed in this workflow to train a ML model. For this particular example, the codeset must include an MLflow project that meets the [MLFlow builder workflow extension requirements](mlflow-builder.md#overview), given that it is consumed by an MLflow builder step that is part of this workflow.
+- the `predictor` parameter is used to specify the type of predictor engine used for the KServe prediction service that will be used to serve the model. It has a default value of `auto`, which will instruct the workflow to automatically select the predictor engine that best fits the trained model.
+- the `prediction-url` output is the URL where the prediction service endpoint can be accessed to run prediction requests against the trained model.
+
+The inputs, parameters and outputs declared globally are available to all steps in the workflow. In the next sections, we'll see how inputs, parameters and outputs are declared for individual steps and how they are connected to the ones declared globally.
+
+```yaml
+steps:
+  - name: builder
+    image: ghcr.io/fuseml/mlflow-builder:v0.3.0
+    inputs:
+      - name: mlflow-codeset
+        codeset:
+          name: "{{ inputs.mlflow-codeset }}"
+          path: /project
+    outputs:
+      - name: image
+```
+
+The `steps` section declares the individual steps that will be executed in the workflow. Steps are executed in the order in which they are listed here.
+
+The first step in the example workflow is an [MLFlow builder step](mlflow-builder.md). Its function is to build a container image that has all the necessary software requirements installed and is able to run the code in the MLflow codeset. The step has the following attributes:
+
+- `name`: uniquely identifies this step in the workflow. This can also be used to reference the step in other places throughout the workflow, for example to consume its output in the next step.
+- `image`: the container image implementing the workflow step. In our case, this is the [MLFlow builder step](mlflow-builder.md) container image that is maintained by the FuseML team.
+- `mlflow-codeset` input: the codeset that contains the MLflow project and code that will be used to train the ML model. Note how this input references the global input with the same name.
+- `image` output: the MLflow runtime container image built by this step that is used at the next step to train the ML model.
+
+```yaml
+  - name: trainer
+    image: "{{ steps.builder.outputs.image }}"
+    inputs:
+      - name: mlflow-codeset
+        codeset:
+          name: "{{ inputs.mlflow-codeset }}"
+          path: "/project"
+    outputs:
+      - name: mlflow-model-url
+    extensions:
+      - name: mlflow-tracking
+        product: mlflow
+        service_resource: mlflow-tracking
+      - name: mlflow-store
+        product: mlflow
+        service_resource: s3
+```
+
+The second step in the workflow is responsible for executing the ML code in the input codeset to train a ML model and return the location where the trained model is stored in the MLflow artifact store. The step has the following attributes:
+
+- `name`: uniquely identifies this step in the workflow.
+- `image`: the container image implementing the workflow step. The expression `{{ steps.builder.outputs.image }}` is used to reference the image built by the previous step.
+- `mlflow-codeset` input: the codeset that contains the MLflow project and code that will be used to train the ML model. Note how this input references the global input with the same name.
+- `mlflow-model-url` output: the URL where the trained model is stored in the MLflow artifact store. This value is used as input in the next step to create the prediction service that serves the trained model.
+- `extensions` is used as a way to reference 3rd party tools and services that are registered with the FuseML Extension Registry. In our example, the MLflow code needs to access a remote MLflow Tracking service to store logs and metrics and the S3 back-end of its artifact store. The FuseML workflow engine will automatically resolve these references and provide the configuration values necessary to access the services in the form of environment variables.
+
+```yaml
+  - name: predictor
+    image: ghcr.io/fuseml/kserve-predictor:v0.3.0
+    inputs:
+      - name: model
+        value: "{{ steps.trainer.outputs.mlflow-model-url }}"
+      - name: predictor
+        value: "{{ inputs.predictor }}"
+      - name: app_name
+        value: "{{ inputs.mlflow-codeset.name }}-{{ inputs.mlflow-codeset.project }}"
+    outputs:
+      - name: prediction-url
+    extensions:
+      - name: s3-storage
+        service_resource: s3
+      - name: kserve
+        service_resource: kserve-api
+```
+
+The third and final step in the workflow is responsible for creating a KServe prediction service that can be used to run predictions against the model trained and stored at the previous step. The service instance will be recorded by FuseML in the form of a FuseML Application. The step has the following attributes:
+
+- `name`: uniquely identifies this step in the workflow.
+- `image`: the container image implementing the workflow step. In our case, this is the [KServe predictor step](kserve-predictor.md) container image that is maintained by the FuseML team.
+- `predictor` parameter: this is a KServe predictor specific parameter that can be used to configure the type of KServe predictor engine used for the prediction service.
+- `app_name` parameter: this is another KServe predictor specific parameter. It determines the name of the FuseML application used to represent the KServe prediction service. Its value also determines the prediction URL as well as the names of the Kubernetes resources created by the KServe predictor. Our example uses an expression to dynamically sets the `app_name` parameter to the name and project of the MLflow codeset used as workflow input.
+- `prediction-url` output: the URL exposed by the KServe prediction service where prediction requests can be sent to the served ML model.
+- `extensions` is used as a way to reference 3rd party tools and services that are registered with the FuseML Extension Registry. In our example, the KServe prediction step needs access to a cluster where KServe is installed. The FuseML workflow engine will automatically resolve this reference and provide the configuration values necessary to access the KServe API services in the form of environment variables to the workflow step container image.
+
+## FuseML Workflow Extensions
+
+A set of container images implementing various workflow extensions are maintained by the FuseML team. If you are interested in using a specific workflow extension, you can find the container image implementing it in the [FuseML extensions repository](https://github.com/fuseml/extensions/tree/main/images). They can be used in FuseML workflows to easily integrate with 3rd party tools and services providing features like ML experiment tracking, artifact storage, prediction services, and more: 
+
+- [MLFlow builder](mlflow-builder.md) - builds python runtime environment container images for codesets that are structured according to the [MLFlow Project format](https://www.mlflow.org/docs/latest/projects.html).
+- [KServe predictor](kserve-predictor.md) - deploys models using the [KServe inference platform](https://kserve.github.io/website/).
+- [Seldon Core predictor](seldon-core-predictor.md) - deploys ML models using the [Seldon Core MLOps platform](https://docs.seldon.io/projects/seldon-core/en/latest/).
+- [OVMS converter](ovms-converter.md) and [predictor](ovms-predictor.md) - can be used to optimize and convert ML models into the Intel IR format with the [OpenVINO Model Optimizer](https://docs.openvino.ai/latest/openvino_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html) and then deploy them using the [OpenVINO Model Server](https://docs.openvino.ai/latest/openvino_docs_ovms.html).
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,8 @@ nav:
       - Seldon Core predictor workflow extension: workflows/seldon-core-predictor.md
       - OpenVINO Model Server predictor workflow extension: workflows/ovms-predictor.md
       - OpenVINO Model Server converter workflow extension: workflows/ovms-converter.md
+  - Extensions:
+      - FuseML extension registry: extensions/extension-registry.md
   - Architecture: architecture.md
   - API Reference: api.md
   - CLI Reference: cli.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
       - OpenVINO Model Server converter workflow extension: workflows/ovms-converter.md
   - Extensions:
       - FuseML extension registry: extensions/extension-registry.md
+      - FuseML installer extensions: extensions/installer-extensions.md
   - Architecture: architecture.md
   - API Reference: api.md
   - CLI Reference: cli.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,13 @@ nav:
       - Training & Serving ML Models on GPU with NVIDIA Triton: tutorials/kserve-triton-gpu.md
       - Benchmarking ML Models on Intel CPUs with Intel OpenVINO: tutorials/openvino-mlflow.md
       - FuseML Extension Development Use-Case - OpenVINO: tutorials/openvino-extensions.md
+  - Workflows:
+      - FuseML workflows: workflows/workflows.md
+      - MLflow builder workflow extension: workflows/mlflow-builder.md
+      - KServe predictor workflow extension: workflows/kserve-predictor.md
+      - Seldon Core predictor workflow extension: workflows/seldon-core-predictor.md
+      - OpenVINO Model Server predictor workflow extension: workflows/ovms-predictor.md
+      - OpenVINO Model Server converter workflow extension: workflows/ovms-converter.md
   - Architecture: architecture.md
   - API Reference: api.md
   - CLI Reference: cli.md


### PR DESCRIPTION
This is a backport of multiple documentation sections that landed after the 0.3 release: #49 and #50.

* section on workflows and mlflow-builder workflow extension
* extensions documentation section with sections based on the Extension Registry
and Installer Extensions blueprints published in the fuseml/fuseml repository [1][2], with some
minor changes to make it more suitable for end users and to provide
more up-to-date and relevant examples.


[1] https://github.com/fuseml/fuseml/blob/main/docs/blueprints/003-extension-registry.md
[2] https://github.com/fuseml/fuseml/blob/main/docs/blueprints/001-installation-of-extensions.md

